### PR TITLE
Explicitly include *.so in wheel

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,7 +9,10 @@ description = ""
 authors = ["Fulcrum Inc. <hello@fulcrum.so>"]
 readme = "README.md"
 packages = [{ include = "fibonacci" }]
-include = [{ path = "src/", format = "sdist" }]
+include = [
+    { path = "src/", format = "sdist" },
+    { path = "fibonacci/*.so", format = "wheel" },
+]
 
 [tool.poetry.build]
 script = "build.py"


### PR DESCRIPTION
every file in your package directory will be included in the package, unless it is ignored by your .gitignore (see https://github.com/python-poetry/poetry/issues/2015)

since we gitignore *.so files, we need to explicitly include them when building wheel