### PR TITLE
Fixed build dependency version

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -339,13 +339,13 @@ files = [
 
 [[package]]
 name = "typing-extensions"
-version = "4.7.1"
-description = "Backported and Experimental Type Hints for Python 3.7+"
+version = "4.8.0"
+description = "Backported and Experimental Type Hints for Python 3.8+"
 optional = false
-python-versions = ">=3.7"
+python-versions = ">=3.8"
 files = [
-    {file = "typing_extensions-4.7.1-py3-none-any.whl", hash = "sha256:440d5dd3af93b060174bf433bccd69b0babc3b15b1a8dca43789fd7f61514b36"},
-    {file = "typing_extensions-4.7.1.tar.gz", hash = "sha256:b75ddc264f0ba5615db7ba217daeb99701ad295353c45f9e95963337ceeeffb2"},
+    {file = "typing_extensions-4.8.0-py3-none-any.whl", hash = "sha256:8f92fc8806f9a6b641eaa5318da32b44d401efaac0f6678c9bc448ba3605faa0"},
+    {file = "typing_extensions-4.8.0.tar.gz", hash = "sha256:df8e4339e9cb77357558cbdbceca33c303714cf861d1eef15e1070055ae8b7ef"},
 ]
 
 [[package]]
@@ -382,4 +382,4 @@ files = [
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.11"
-content-hash = "e3ad7c804dc2c276811b870566b3312ce9d219aeafb89ad91720bb37195b4fb7"
+content-hash = "ef99d8200191dab0c02469500da4962d36dec8aecb8ad8435d626ad032502d38"

--- a/poetry.lock
+++ b/poetry.lock
@@ -382,4 +382,4 @@ files = [
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.11"
-content-hash = "ef99d8200191dab0c02469500da4962d36dec8aecb8ad8435d626ad032502d38"
+content-hash = "c8130643bdfe2817a88945c5787f8268bd99ff459b6b2d95395ee9b1cb327cea"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["poetry-core", "ziggy-pydust"]
+requires = ["poetry-core", "ziggy-pydust==0.5.0"]
 build-backend = "poetry.core.masonry.api"
 
 [tool.poetry]
@@ -21,8 +21,8 @@ script = "build.py"
 python = "^3.11"
 
 [tool.poetry.group.dev.dependencies]
+ziggy-pydust = "0.5.0"
 pytest = "^7.4.0"
-ziggy-pydust = "^0.5.0"
 ruff = "^0.0.290"
 black = "^23.7.0"
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["poetry-core", "ziggy-pydust==0.5.0"]
+requires = ["poetry-core", "ziggy-pydust==0.5.*"]
 build-backend = "poetry.core.masonry.api"
 
 [tool.poetry]
@@ -21,7 +21,7 @@ script = "build.py"
 python = "^3.11"
 
 [tool.poetry.group.dev.dependencies]
-ziggy-pydust = "0.5.0"
+ziggy-pydust = "0.5.*"
 pytest = "^7.4.0"
 ruff = "^0.0.290"
 black = "^23.7.0"


### PR DESCRIPTION
These versions should be the same. Unfortunately, there is no better way to guarantee than with poetry. Also, build dependency should be constrained as we might be making breaking changes.