### PR TITLE
Upgrade ziggy-pydust to 0.12.3

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -59,3 +59,5 @@ jobs:
         run: poetry run black .
       - name: Pytest
         run: poetry run pytest
+      - name: Check stubs
+        run: poetry run python -m ziglang build generate-stubs -Dcheck-stubs=true

--- a/.gitignore
+++ b/.gitignore
@@ -163,4 +163,3 @@ zig-out/
 
 pydust.build.zig
 build.zig
-*.pyi

--- a/fibonacci/_lib.pyi
+++ b/fibonacci/_lib.pyi
@@ -1,0 +1,31 @@
+from __future__ import annotations
+
+def nth_fibonacci_iterative(n, /): ...
+def nth_fibonacci_recursive(n, /, *, f0=0, f1=1): ...
+def nth_fibonacci_recursive_tail(n, /): ...
+
+class Fibonacci:
+    """
+    A class that computes the Fibonacci numbers.
+    """
+
+    def __init__(first_n, /):
+        pass
+    def __iter__(self, /):
+        """
+        Implement iter(self).
+        """
+        ...
+
+class FibonacciIterator:
+    """
+    An iterator that computes the Fibonacci numbers.
+    """
+
+    def __init__(i, ith, next, stop, /):
+        pass
+    def __next__(self, /):
+        """
+        Implement next(self).
+        """
+        ...

--- a/poetry.lock
+++ b/poetry.lock
@@ -104,13 +104,13 @@ files = [
 
 [[package]]
 name = "packaging"
-version = "23.1"
+version = "23.2"
 description = "Core utilities for Python packages"
 optional = false
 python-versions = ">=3.7"
 files = [
-    {file = "packaging-23.1-py3-none-any.whl", hash = "sha256:994793af429502c4ea2ebf6bf664629d07c1a9fe974af92966e4b8d2df7edc61"},
-    {file = "packaging-23.1.tar.gz", hash = "sha256:a392980d2b6cffa644431898be54b0045151319d1e7ec34f0cfed48767dd334f"},
+    {file = "packaging-23.2-py3-none-any.whl", hash = "sha256:8c491190033a9af7e1d931d0b5dacc2ef47509b34dd0de67ed209b5203fc88c7"},
+    {file = "packaging-23.2.tar.gz", hash = "sha256:048fb0e9405036518eaaf48a55953c750c11e1a1b68e0dd1a9d62ed0c092cfc5"},
 ]
 
 [[package]]
@@ -126,13 +126,13 @@ files = [
 
 [[package]]
 name = "platformdirs"
-version = "3.10.0"
+version = "3.11.0"
 description = "A small Python package for determining appropriate platform-specific dirs, e.g. a \"user data dir\"."
 optional = false
 python-versions = ">=3.7"
 files = [
-    {file = "platformdirs-3.10.0-py3-none-any.whl", hash = "sha256:d7c24979f292f916dc9cbf8648319032f551ea8c49a4c9bf2fb556a02070ec1d"},
-    {file = "platformdirs-3.10.0.tar.gz", hash = "sha256:b45696dab2d7cc691a3226759c0d3b00c47c8b6e293d96f6436f733303f77f6d"},
+    {file = "platformdirs-3.11.0-py3-none-any.whl", hash = "sha256:e9d171d00af68be50e9202731309c4e658fd8bc76f55c11c7dd760d023bda68e"},
+    {file = "platformdirs-3.11.0.tar.gz", hash = "sha256:cf8ee52a3afdb965072dcc652433e0c7e3e40cf5ea1477cd4b3b1d2eb75495b3"},
 ]
 
 [package.extras]
@@ -366,13 +366,13 @@ files = [
 
 [[package]]
 name = "ziggy-pydust"
-version = "0.11.1"
+version = "0.12.3"
 description = ""
 optional = false
 python-versions = ">=3.11,<4.0"
 files = [
-    {file = "ziggy_pydust-0.11.1-py3-none-any.whl", hash = "sha256:5796a69b2ca71b6356c2a2676236ad15facaacf34e1f35de11e19e3e3ff2ad56"},
-    {file = "ziggy_pydust-0.11.1.tar.gz", hash = "sha256:90e7777c8f81c23b3d3c15ff799d5bce9405b45805812079cfb6a473d0f707d6"},
+    {file = "ziggy_pydust-0.12.3-py3-none-any.whl", hash = "sha256:734ab253ad3db00262fd163819ede822d793d9ec0780c9ce1e08a0b3d1b295b4"},
+    {file = "ziggy_pydust-0.12.3.tar.gz", hash = "sha256:30578c0ffd003fd0900209412b273ebcf8c5a34d34feb692aa40e0b0d59f376f"},
 ]
 
 [package.dependencies]
@@ -400,4 +400,4 @@ files = [
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.11"
-content-hash = "800160a503a63d1fe05ea61a71453f1518245abb68d72d1e36298ffdace70328"
+content-hash = "e3f4b21abbfe269579af7160ec5d99bcf8e0e885cd9b2b93edd508cdd259f203"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["poetry-core", "ziggy-pydust==0.11.1"]
+requires = ["poetry-core", "ziggy-pydust==0.12.3"]
 build-backend = "poetry.core.masonry.api"
 
 [tool.poetry]
@@ -22,7 +22,7 @@ script = "build.py"
 python = "^3.11"
 
 [tool.poetry.group.dev.dependencies]
-ziggy-pydust = "0.11.1"
+ziggy-pydust = "0.12.3"
 pytest = "^7.4.0"
 ruff = "^0.0.292"
 black = "^23.7.0"


### PR DESCRIPTION
Accounts for changes in stub generation where stubs need to be checked in
